### PR TITLE
Remove extra space in config_editor_handler.py

### DIFF
--- a/lib/config_editor_handler.py
+++ b/lib/config_editor_handler.py
@@ -120,7 +120,7 @@ def add_external_command():
         ]
         detector_post = [
             {
-                "command": "python3  " + config.fd_tone_notify_extension_path + "post_record.py [timestamp] \"[detectorName]\" [recordingRelPath] [custom]",
+                "command": "python3 " + config.fd_tone_notify_extension_path + "post_record.py [timestamp] \"[detectorName]\" [recordingRelPath] [custom]",
                 "description": "fd_extension",
                 "custom": {
                     "department_number": "",


### PR DESCRIPTION
I missed the second line with a errant space in the last commit.  :)